### PR TITLE
Adding support for zOS

### DIFF
--- a/ts_other.go
+++ b/ts_other.go
@@ -1,4 +1,4 @@
-// +build !windows,!darwin,!freebsd,!netbsd,!openbsd,!linux,!solaris
+// +build !windows,!darwin,!freebsd,!netbsd,!openbsd,!linux,!solaris,!zos
 
 // Copyright 2014 Oleku Konko All rights reserved.
 // Use of this source code is governed by a MIT

--- a/ts_x.go
+++ b/ts_x.go
@@ -1,4 +1,4 @@
-// +build !windows,!solaris
+// +build !windows,!solaris,!zos
 
 // Copyright 2014 Oleku Konko All rights reserved.
 // Use of this source code is governed by a MIT

--- a/ts_zos.go
+++ b/ts_zos.go
@@ -9,7 +9,6 @@
 package ts
 
 import (
-	"syscall"
 	"golang.org/x/sys/unix"
 )
 

--- a/ts_zos.go
+++ b/ts_zos.go
@@ -12,10 +12,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const (
-	TIOCGWINSZ = 21608
-)
-
 // Get Windows Size
 func GetSize() (ws Size, err error) {
 	var wsz *unix.Winsize

--- a/ts_zos.go
+++ b/ts_zos.go
@@ -1,0 +1,31 @@
+// +build zos
+
+// Copyright 2017 Oleku Konko All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+// This module is a Terminal  API for the Go Programming Language.
+// The protocols were written in pure Go and works on windows and unix systems
+package ts
+
+import (
+	"syscall"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	TIOCGWINSZ = 21608
+)
+
+// Get Windows Size
+func GetSize() (ws Size, err error) {
+	var wsz *unix.Winsize
+	wsz, err = unix.IoctlGetWinsize(syscall.Stdout, syscall.TIOCGWINSZ)
+
+	if err != nil {
+		ws = Size{80, 25, 0, 0}
+	} else {
+		ws = Size{wsz.Row, wsz.Col, wsz.Xpixel, wsz.Ypixel}
+	}
+	return ws, err
+}

--- a/ts_zos.go
+++ b/ts_zos.go
@@ -20,7 +20,7 @@ const (
 // Get Windows Size
 func GetSize() (ws Size, err error) {
 	var wsz *unix.Winsize
-	wsz, err = unix.IoctlGetWinsize(syscall.Stdout, unix.TIOCGWINSZ)
+	wsz, err = unix.IoctlGetWinsize(unix.Stdout, unix.TIOCGWINSZ)
 
 	if err != nil {
 		ws = Size{80, 25, 0, 0}

--- a/ts_zos.go
+++ b/ts_zos.go
@@ -20,7 +20,7 @@ const (
 // Get Windows Size
 func GetSize() (ws Size, err error) {
 	var wsz *unix.Winsize
-	wsz, err = unix.IoctlGetWinsize(syscall.Stdout, syscall.TIOCGWINSZ)
+	wsz, err = unix.IoctlGetWinsize(syscall.Stdout, unix.TIOCGWINSZ)
 
 	if err != nil {
 		ws = Size{80, 25, 0, 0}


### PR DESCRIPTION
The current implementation uses syscalls in a way that are not supported by zOS. In order to increase compatibility, a new zos-specific build needs to be added.